### PR TITLE
Sanitize uploaded filenames to prevent job creation errors

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -88,11 +88,14 @@ async def create_job(
     jdir = JOBS_DIR / jid
     (jdir/"input").mkdir(parents=True, exist_ok=True)
     (jdir/"out").mkdir(parents=True, exist_ok=True)
-    raw_path = jdir/"input"/file.filename
+    safe_name = Path(file.filename).name
+    if not safe_name:
+        raise HTTPException(400, "invalid filename")
+    raw_path = jdir/"input"/safe_name
     with open(raw_path, "wb") as f:
         f.write(await file.read())
 
-    JOB_STATUS[jid] = {"state": "queued", "msg": "", "filename": file.filename}
+    JOB_STATUS[jid] = {"state": "queued", "msg": "", "filename": safe_name}
 
     async def run():
         def log(m):


### PR DESCRIPTION
## Summary
- Sanitize `UploadFile.filename` and reject empty names during job creation
- Record sanitized name in job status to avoid server errors on unusual filenames

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c65bddff0883309f545539e8dee9bb